### PR TITLE
Handle list value in the memberOf attribute

### DIFF
--- a/harvardkey_cas/backends.py
+++ b/harvardkey_cas/backends.py
@@ -103,7 +103,13 @@ class CASAuthBackend(CASBackend):
             # fetch the user's groups and add them to the session
             try:
                 memberOf = attributes.get(u'memberOf')
-                group_ids = list(map(str.strip, memberOf.strip("[]").split(',')))
+                group_ids = None
+
+                if type(memberOf) is list:
+                    group_ids = memberOf
+                else:
+                    group_ids = list(map(str.strip, memberOf.strip("[]").split(',')))
+
                 if group_ids:
                     request.session['USER_GROUPS'] = group_ids
                     logger.debug(">>> storing groups for user %s in session "
@@ -117,4 +123,3 @@ class CASAuthBackend(CASBackend):
             logger.warn(" no user attributes found in CAS response")
 
         return user
-

--- a/harvardkey_cas/backends.py
+++ b/harvardkey_cas/backends.py
@@ -105,17 +105,18 @@ class CASAuthBackend(CASBackend):
                 memberOf = attributes.get(u'memberOf')
                 group_ids = None
 
-                if type(memberOf) is list:
-                    group_ids = memberOf
-                else:
-                    group_ids = list(map(str.strip, memberOf.strip("[]").split(',')))
+                if memberOf:
+                    if type(memberOf) is list:
+                        group_ids = memberOf
+                    else:
+                        group_ids = list(map(str.strip, memberOf.strip("[]").split(',')))
 
-                if group_ids:
-                    request.session['USER_GROUPS'] = group_ids
-                    logger.debug(">>> storing groups for user %s in session "
-                                 "%s" % (user.username, group_ids))
+                    if group_ids:
+                        request.session['USER_GROUPS'] = group_ids
+                        logger.debug(">>> storing groups for user %s in session "
+                                    "%s" % (user.username, group_ids))
                 else:
-                    logger.error('No user groups from CAS handshake')
+                    logger.warning('No user groups from CAS handshake')
             except Exception as ex:
                 logger.error('could not load user groups, ex=%s' % ex)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-harvardkey-cas',
-    version='0.1',
+    version='1.1',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',  # example license

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
     ],
     install_requires=[
         "Django>=1.9",
-        "django-cas-ng",
+        "django-cas-ng==3.6.0",
     ],
 )


### PR DESCRIPTION
Different versions of the CAS server may return the memberOf attribute either as a string or as a list.  This change allows us to handle either type.
