### PR TITLE
relax restriction on django-cas-ng (allow 4.x)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-harvardkey-cas',
-    version='2.1',
+    version='2.2',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',  # example license
@@ -34,6 +34,6 @@ setup(
     ],
     install_requires=[
         "Django>=2.2.4",
-        "django-cas-ng==3.6.0",
+        "django-cas-ng>=3.6.0,<5",
     ],
 )


### PR DESCRIPTION
Relaxes restriction in setup.py to >=3.6.0,<5.

Tagged `v2.2`.

Successfully `pip installed` locally; did not test locally (will test as part of fixes to https://github.com/Harvard-University-iCommons/syllabus-sso/pull/17).

See [discussion in #at-dev](https://tlt.slack.com/archives/C8BUWT25R/p1606833755011200).