### PR TITLE
TLT-4026: Upgrade to Django 3.2

### DIFF
--- a/harvardkey_cas/decorators.py
+++ b/harvardkey_cas/decorators.py
@@ -9,7 +9,7 @@ def group_membership_restriction(allowed_groups,
                                  redirect_url=reverse_lazy('not_authorized'),
                                  raise_exception=False):
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if not isinstance(allowed_groups, (list, tuple)):
                 allowed = (allowed_groups, )

--- a/harvardkey_cas/decorators.py
+++ b/harvardkey_cas/decorators.py
@@ -1,6 +1,5 @@
 from functools import wraps
 from django.core.exceptions import PermissionDenied
-from django.utils.decorators import available_attrs
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        "Django>=2.2.4",
+        "Django>=3.0.0",
         "django-cas-ng>=4.2.1,<5",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-harvardkey-cas',
-    version='2.4',
+    version='3.0',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',  # example license


### PR DESCRIPTION
Django removed the last few remaining Python 2-compatible Django APIs in version 3.0 (more information in the Django 3.0 [release notes](https://docs.djangoproject.com/en/4.0/releases/3.0/#removed-private-python-2-compatibility-apis)). This update removes one of those relic APIs that is not compatible with `django >= 3.0`.

Specifically, this is done in an effort to update `slack_ops` to Django 3.2.13, the latest LTS version.

Any of our Django apps that are upgraded to Django 3.x and use this library will need to use this updated version to maintain compatibility with Django.